### PR TITLE
Update otg_hs.h

### DIFF
--- a/include/libopencm3/stm32/otg_hs.h
+++ b/include/libopencm3/stm32/otg_hs.h
@@ -266,6 +266,7 @@
 
 /* OTG_FS general core configuration register (OTG_HS_GCCFG) */
 /* Bits 31:21 - Reserved */
+#define OTG_HS_GCCFG_NOVBUSSENS  (1<<21)
 #define OTG_HS_GCCFG_SOFOUTEN		(1 << 20)
 #define OTG_HS_GCCFG_VBUSBSEN		(1 << 19)
 #define OTG_HS_GCCFG_VBUSASEN		(1 << 18)


### PR DESCRIPTION
added OTG_HS_GCCFG_NOVBUSSENS define in reference to RM0090 http://www.st.com/web/en/resource/technical/document/reference_manual/DM00031020.pdf page 1416
